### PR TITLE
fix catch-all redirect message.

### DIFF
--- a/app/elements/routing.js
+++ b/app/elements/routing.js
@@ -38,8 +38,9 @@ window.addEventListener('WebComponentsReady', () => {
     app.route = 'contact';
   });
 
-  page('*', function() {
-    app.$.toastConfirm.text = `Can't find: ${window.location.href}. Redirected you to Home Page`;
+  page('*', function(attempted) {
+    let url = window.location.href + attempted.path.substr(1);
+    app.$.toastConfirm.text = `Can't find: ${url}. Redirected you to Home Page`;
     app.$.toastConfirm.show();
     page.redirect('/');
   });


### PR DESCRIPTION
Using only `window.location.href` doesn't catch the attempted route. So the message ends up reading:

> Can't find: /users

If attempting an invalid url **from** /users.

So now catch-all will read what Page.js was working with.