### PR TITLE
Set Firebase to false for globals.

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -19,6 +19,7 @@
     "unwrap": true,
     "Polymer": true,
     "Platform": true,
+    "Firebase": false,
     "page": true,
     "app": true
   }


### PR DESCRIPTION
lint-js generates a warning "'Firebase' is not defined." when attempting to lint/test globals in an application using Firebase. This warning prevents gulp from serving or any local development.