### PR TITLE
Reflect changes in metadata files to views. This PR fixes #41

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,6 +24,7 @@ var historyApiFallback = require('connect-history-api-fallback');
 var packageJson = require('./package.json');
 var crypto = require('crypto');
 var config = require('./config');
+var requireUncached = require('require-uncached');
 
 // Get a task path
 function task(filename) {
@@ -53,7 +54,7 @@ gulp.task('lint-js', ['ensureFiles'], function() {
       stream: true,
       once: true
     }));
-    
+
     //.pipe($.if(!browserSync.active, $.jshint.reporter('fail')));
 });
 
@@ -239,7 +240,7 @@ gulp.task('serve', ['js', 'lint', 'lint-js', 'styles'], function() {
     'app/*.html',
     'app/views/**/*.html',
     'app/content/**/*.md',
-    'app/metadata.js'
+    'app/metadata/*.js'
   ], ['styles', reload]);
   gulp.watch(['app/{elements,themes}/**/*.{css,html}'], ['styles', reload]);
   gulp.watch(['app/themes/**/*.js'], ['styles', reload]);
@@ -308,7 +309,7 @@ gulp.task('serve:gae', ['default'], require(task('serve-gae'))($, gulp));
 gulp.task('styles', ['views'], require(task('styles-postcss'))($, config, gulp, merge));
 
 // Compile HTML files with Nunjucks templating engine
-gulp.task('views', require(task('views-nunjucks'))($, config, gulp));
+gulp.task('views', require(task('views-nunjucks'))($, config, gulp, requireUncached));
 
 // Build Production Files, the Default Task
 gulp.task('default', ['clean'], function(cb) {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "postcss-simple-vars": "^1.2.0",
     "psi": "^2.0.2",
     "require-dir": "^0.3.0",
+    "require-uncached": "^1.0.2",
     "run-sequence": "^1.0.2",
     "stylelint": "^4.3.3",
     "stylelint-config-standard": "^3.0.0",

--- a/tasks/views-nunjucks.js
+++ b/tasks/views-nunjucks.js
@@ -1,12 +1,12 @@
 'use strict';
 
 // Compile HTML files with Nunjucks templating engine
-module.exports = function ($, config, gulp) { return function () {
+module.exports = function ($, config, gulp, requireUncached) { return function () {
   var merge = require('merge');
   var metadata = {
-    config: merge(require('../app/metadata/config'), config),
-    theme: require('../app/themes/' + config.appTheme + '/variables')
-  }
+    config: merge(requireUncached('../app/metadata/config'), config),
+    theme: requireUncached('../app/themes/' + config.appTheme + '/variables')
+  };
 
   function markdownRender(markdown) {
     var cm = require('commonmark');
@@ -32,7 +32,7 @@ module.exports = function ($, config, gulp) { return function () {
       }
     }))
     .pipe($.nunjucksHtml({
-      locals: merge(metadata, require('../app/metadata/general')),
+      locals: merge(metadata, requireUncached('../app/metadata/general')),
       searchPaths: ['app/content', 'app/elements', 'app/views'],
       tags: {
         variableStart: '{$',


### PR DESCRIPTION
Due to [require caches](https://nodejs.org/docs/latest/api/modules.html#modules_caching) we haven't seen any changes on view without restarting a server.
[require-uncached](https://github.com/sindresorhus/require-uncached) simply bypass the cache and load last changes in our files.